### PR TITLE
[DEPRECATED] Do not use

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,12 +15,19 @@ config :elixir_phoenix_example_app, ElixirPhoenixExampleApp.Endpoint,
   secret_key_base: "PIW+jnFP5piAAlp679uxb3Px1YD2pA7IQXqnQz67AC/tZXiAoqMpjjJTEFZ6RQXp",
   render_errors: [view: ElixirPhoenixExampleApp.ErrorView, accepts: ~w(html json)],
   pubsub: [name: ElixirPhoenixExampleApp.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+           adapter: Phoenix.PubSub.PG2],
+  instrumenters: [Timber.Integrations.PhoenixInstrumenter]
 
-# Configures Elixir's Logger
-config :logger, :console,
-  format: "$time $metadata[$level] $message\n",
-  metadata: [:request_id]
+# Configure Timber to capture Ecto events
+config :my_app, ElixirPhoenixExampleApp.Repo,
+  loggers: [{Timber.Integrations.EctoLogger, :log, [:info]}]
+
+# Configure logger to use Timber
+config :logger,
+  backends: [Timber.LoggerBackend],
+  handle_otp_reports: false # Timber handles errors, structures them, and adds additional metadata
+
+config :timber, :capture_errors, true
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -26,8 +26,16 @@ config :elixir_phoenix_example_app, ElixirPhoenixExampleApp.Endpoint,
     ]
   ]
 
-# Do not include metadata nor timestamps in development logs
-config :logger, :console, format: "[$level] $message\n"
+# Configure timber to be development friendly
+config :timber,
+  transport: Timber.Transports.IODevice,
+
+config :timber, :io_device,
+  colorize: true,
+  format: :logfmt,
+  print_timestamps: true,
+  print_log_level: true,
+  print_metadata: false
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -28,7 +28,7 @@ config :elixir_phoenix_example_app, ElixirPhoenixExampleApp.Endpoint,
 
 # Configure timber to be development friendly
 config :timber,
-  transport: Timber.Transports.IODevice,
+  transport: Timber.Transports.IODevice
 
 config :timber, :io_device,
   colorize: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,14 @@ config :elixir_phoenix_example_app, ElixirPhoenixExampleApp.Repo,
   database: "elixir_phoenix_example_app_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+# Configure timber to be development friendly
+config :timber,
+  transport: Timber.Transports.IODevice,
+
+config :timber, :io_device,
+  colorize: true,
+  format: :logfmt,
+  print_timestamps: true,
+  print_log_level: true,
+  print_metadata: false

--- a/lib/elixir_phoenix_example_app/endpoint.ex
+++ b/lib/elixir_phoenix_example_app/endpoint.ex
@@ -20,7 +20,6 @@ defmodule ElixirPhoenixExampleApp.Endpoint do
   end
 
   plug Plug.RequestId
-  plug Plug.Logger
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
@@ -37,6 +36,10 @@ defmodule ElixirPhoenixExampleApp.Endpoint do
     store: :cookie,
     key: "_elixir_phoenix_example_app_key",
     signing_salt: "4FnrD7hG"
+
+  # Add Timber plugs for capturing HTTP context and events
+  plug Timber.Integrations.ContextPlug
+  plug Timber.Integrations.EventPlug
 
   plug ElixirPhoenixExampleApp.Router
 end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule ElixirPhoenixExampleApp.Mixfile do
   def application do
     [mod: {ElixirPhoenixExampleApp, []},
      applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger, :gettext,
-                    :phoenix_ecto, :postgrex]]
+                    :phoenix_ecto, :postgrex, :timber]]
   end
 
   # Specifies which paths to compile per environment.
@@ -37,7 +37,8 @@ defmodule ElixirPhoenixExampleApp.Mixfile do
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
-     {:cowboy, "~> 1.0"}]
+     {:cowboy, "~> 1.0"},
+     {:timber, "~> 1.0"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.lock
+++ b/mix.lock
@@ -7,6 +7,7 @@
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
+  "msgpax": {:hex, :msgpax, "1.1.0", "e31625e256db2decca1ae2b841f21b4d2483b1332649ce3ebc96c7ff7a4986e3", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: true]}]},
   "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "phoenix_ecto": {:hex, :phoenix_ecto, "3.2.2", "2e51c57614528b130d54019e78349f83a5b5d53b3b2ef775dbc30df7e1fecb45", [:mix], [{:ecto, "~> 2.1", [hex: :ecto, optional: false]}, {:phoenix_html, "~> 2.9", [hex: :phoenix_html, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.9.3", "1b5a2122cbf743aa242f54dced8a4f1cc778b8bd304f4b4c0043a6250c58e258", [:mix], [{:plug, "~> 1.0", [hex: :plug, optional: false]}]},
@@ -16,4 +17,5 @@
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "postgrex": {:hex, :postgrex, "0.13.1", "ebf17b7348922af9db8b4d70f946328ab9ef5123526bf05567d9306393fce104", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
-  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []}}
+  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []},
+  "timber": {:hex, :timber, "1.0.16", "19df443ebb2d1644a7a85260ef1eb184bf6c84c8aef1d0791a9e86c23d09efe2", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}, {:hackney, "~> 1.6", [hex: :hackney, optional: true]}, {:msgpax, "~> 1.0", [hex: :msgpax, optional: false]}, {:phoenix, "~> 1.2", [hex: :phoenix, optional: true]}, {:plug, "~> 1.2", [hex: :plug, optional: true]}, {:poison, "~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]}}

--- a/web/web.ex
+++ b/web/web.ex
@@ -28,7 +28,7 @@ defmodule ElixirPhoenixExampleApp.Web do
 
   def controller do
     quote do
-      use Phoenix.Controller
+      use Phoenix.Controller, log: false
 
       alias ElixirPhoenixExampleApp.Repo
       import Ecto


### PR DESCRIPTION
Please see the open pull requests. And installing timber is now a simple install command `mix timber.install api-key`.