### PR TITLE
[DEPRECATED] Do not use

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,6 +27,11 @@ config :logger,
   backends: [Timber.LoggerBackend],
   handle_otp_reports: false # Timber handles errors, structures them, and adds additional metadata
 
+config :timber,
+  transport: Timber.Transports.HTTP,
+  api_key: System.get_env("TIMBER_LOGS_KEY"),
+  http_client: Timber.Transports.HTTP.HackneyClient
+
 config :timber, :capture_errors, true
 
 # Import environment specific config. This must remain at the bottom

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule ElixirPhoenixExampleApp.Mixfile do
   def application do
     [mod: {ElixirPhoenixExampleApp, []},
      applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger, :gettext,
-                    :phoenix_ecto, :postgrex, :timber]]
+                    :phoenix_ecto, :postgrex, :hackney, :timber]]
   end
 
   # Specifies which paths to compile per environment.
@@ -38,6 +38,7 @@ defmodule ElixirPhoenixExampleApp.Mixfile do
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
+     {:hackney, "~> 1.6"},
      {:timber, "~> 1.0"}]
   end
 


### PR DESCRIPTION
Please see the open pull requests. And installing timber is now a simple install command `mix timber.install api-key`.